### PR TITLE
can't write in /etc unless you are root

### DIFF
--- a/tasks/template.yml
+++ b/tasks/template.yml
@@ -1,6 +1,7 @@
 ---
 
 - name: template > Template
+  sudo: True
   template:
     src:  "{{ elao_motd_template }}"
     dest: "{{ elao_motd_file }}"


### PR DESCRIPTION
```
TASK: [ansible-role-motd | template > Template] ******************************* 
failed: [default] => {"failed": true}
msg: Destination /etc not writable

FATAL: all hosts have already failed -- aborting
```
